### PR TITLE
fix: 채팅방 구독 해제 이벤트 처리 도입

### DIFF
--- a/client/src/pages/ChatRoom.tsx
+++ b/client/src/pages/ChatRoom.tsx
@@ -48,7 +48,9 @@ export default function ChatRoom() {
         const subscription = stompClient.subscribe(`/topic/chat-rooms/${chatRoomId}`, callback);
 
         return () => {
-            subscription.unsubscribe();
+            subscription.unsubscribe({
+                destination: `/topic/chat-rooms/${chatRoomId}`,
+            });
         };
 
     }, [chatRoomId, joined, stompClient]);

--- a/server/src/main/java/com/example/spring_websocket/websocket/WebSocketHandler.java
+++ b/server/src/main/java/com/example/spring_websocket/websocket/WebSocketHandler.java
@@ -1,13 +1,14 @@
 package com.example.spring_websocket.websocket;
 
+import com.example.spring_websocket.chatroom.ChatRoomService;
 import com.example.spring_websocket.member.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
-import org.springframework.messaging.Message;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
 
 @Component
 @RequiredArgsConstructor
@@ -15,24 +16,40 @@ import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 public class WebSocketHandler {
 
     private final MemberService memberService;
+    private final ChatRoomService chatRoomService;
 
     /**
      * STOMP 서브 프로토콜을 사용하는 웹소켓 세션의 연결이 끊기면 발생하는 이벤트 {@link SessionDisconnectEvent}를 처리합니다.
      */
     @EventListener
     public void handleSessionDisconnect(SessionDisconnectEvent event) {
-        Long memberId = getMemberIdFromMessage(event.getMessage());
+        SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.wrap(event.getMessage());
+        Long memberId = getMemberIdFromHeaderAccessor(accessor);
 
         memberService.leave(memberId);
     }
 
-    private Long getMemberIdFromMessage(Message<byte[]> event) {
-        SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.wrap(event);
+    @EventListener
+    public void handleSessionUnsubscribe(SessionUnsubscribeEvent event) {
+        SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.wrap(event.getMessage());
+        Long memberId = getMemberIdFromHeaderAccessor(accessor);
+        Long chatRoomId = getChatRoomIdFromHeaderAccessor(accessor);
+        chatRoomService.leave(memberId, chatRoomId);
+    }
 
+    private Long getMemberIdFromHeaderAccessor(SimpMessageHeaderAccessor accessor) {
         if (accessor.getSessionAttributes() == null || !accessor.getSessionAttributes().containsKey("memberId")) {
             throw new IllegalStateException("No SessionAttributes or memberId. sessionId: " + accessor.getSessionId());
         }
 
         return (Long) accessor.getSessionAttributes().get("memberId");
+    }
+
+    private Long getChatRoomIdFromHeaderAccessor(SimpMessageHeaderAccessor accessor) {
+        if (accessor.getDestination() == null || !accessor.getDestination().startsWith("/topic/chat-rooms/")) {
+            throw new IllegalStateException("No destination or destination is not start with '/topic/chat-rooms/'. destination: " + accessor.getDestination());
+        }
+
+        return Long.parseLong(accessor.getDestination().replace("/topic/chat-rooms/", ""));
     }
 }


### PR DESCRIPTION
## 변경 사항
- 채팅방 화면에서 다른 화면으로 이동시 채팅방 나가기가 동작하도록 수정되었습니다.
- [서버] SessionUnsubscribeEvent를 처리하는 로직을 WebSocketHandler에 추가하였습니다. chatRoomService.leave()로 처리합니다.
- [클라이언트] 채팅방에 대한 unsubscribe 메시지 전송 시 destination 헤더를 포함하도록 수정하였습니다.

## 참고 사항 및 주의 사항
- destination 헤더는 ubsubscribe의 기본 스펙이 아닌데, `/topic/chat-rooms/${chatRoomId}` 형식으로 보내고 파싱하고를 넣어야 할까요? 아니면 chatRoomId: chatRoomId 이런식으로 하는게 나을까요?

## 관련 이슈
- #16 